### PR TITLE
Add Perl 4 soundex "joke" snippet (MIKESTOK)

### DIFF
--- a/snippets/MIKESTOK/soundex.pl
+++ b/snippets/MIKESTOK/soundex.pl
@@ -1,0 +1,8 @@
+sub Soundex
+{
+  local ($_, $f) = shift;
+
+  y;a-z;A-Z;;y;A-Z;;cd;$_ ne q???do{($f)=m;^(.);;s;$f+;;;
+  y;AEHIOUWYBFPVCGJKQSXZDTLMNR;00000000111122222222334556;;
+  y;;;cs;y;0;;d;s;^;$f;;s;$;0000;;m;(^.{4});;$1;}:q;;;
+}


### PR DESCRIPTION
From an article I wrote for the Perl Review 0.6 (November 2002):

> […] I will use the Soundex function as an example, as the algorithm
> is simple and my Perl implementation will reveal something about
> my abilities as a programmer.
>
> The Soundex algorithm is a simple hashing of the letters of a word
> to a four character code which brings similar sounding words to the
> same code. In 1994 I posted a routine, shown in code listing 1, to
> comp.lang.perl which shows both the simplicity of the Soundex
> algorithm and my Perl style at its worst (or best).

This was written as a joke because people had complained that Perl could be considered unreadable.

A slightly reformatted, bug-fixed, and documented version of this was included in the core Perl distribution for a while. Luckily it was taken over and rewritten to become
[Text::Soundex](https://metacpan.org/pod/Text::Soundex)